### PR TITLE
CRAN badge fix

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,10 +16,8 @@ knitr::opts_chunk$set(
 # croquet
 
 <!-- badges: start -->
-[![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![CRAN
-status](https://www.r-pkg.org/badges/version/gtreg)](https://CRAN.R-project.org/package=gtreg)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![CRAN status](https://www.r-pkg.org/badges/version/croquet)](https://CRAN.R-project.org/package=croquet)
 <!-- badges: end -->
 
 A collection of clinical research organization (CRO) miscellaneous functions 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![CRAN
-status](https://www.r-pkg.org/badges/version/gtreg)](https://CRAN.R-project.org/package=gtreg)
+status](https://www.r-pkg.org/badges/version/croquet)](https://CRAN.R-project.org/package=croquet)
 <!-- badges: end -->
 
 A collection of clinical research organization (CRO) miscellaneous


### PR DESCRIPTION
The CRAN badge on the README page was pointing to gtreg instead of croquet. Because gtreg is on CRAN, it made it appear as though croquet were also on CRAN.