### PR TITLE
Clarify documentation for `*labelled_sheet()` functions

### DIFF
--- a/R/add_labelled_sheet.R
+++ b/R/add_labelled_sheet.R
@@ -10,7 +10,7 @@
 #' @param wrkbk workbook object, defaults to wb
 #' @param start_row integer row position where Labels are placed, defaults to 1L
 #'
-#' @return a workbook object
+#' @return a list containing worksheet definition; the function modifies the object passed to the `wb` argument.
 #' @export
 #'
 #' @examples

--- a/R/add_labelled_sheet.R
+++ b/R/add_labelled_sheet.R
@@ -31,8 +31,8 @@
 #'     var_3 = "Variable 3 (date)"
 #'   )
 #' wb <- createWorkbook()
-#' add_labelled_sheet(dat1)
-#' add_labelled_sheet(dat1, sheet_name = "example sheet")
+#' add_labelled_sheet(data = dat1, wrkbk = wb)
+#' add_labelled_sheet(data = dat1, sheet_name = "example sheet", wrkbk = wb)
 #' saveWorkbook(wb, "checkwb.xlsx")
 #'
 #'
@@ -50,7 +50,7 @@
 #'
 #' out <- tibble::lst(dat1, dat2)
 #' wb <- createWorkbook()
-#' add_labelled_sheet(out)
+#' add_labelled_sheet(data = out, wrkbk = wb)
 #' saveWorkbook(wb, "checkwb.xlsx")
 #'}
 #'

--- a/R/labelled_sheet.R
+++ b/R/labelled_sheet.R
@@ -9,7 +9,7 @@
 #' @param wrkbk workbook name, defaults to wb
 #' @param start_row integer row position where the labels must be placed, `data` is placed at start_row+1, defaults to 1L
 #'
-#' @return a workbook object
+#' @return a list containing worksheet definition; the function modifies the object passed to the `wb` argument.
 #'
 #' @examples
 #' \dontrun{

--- a/README.Rmd
+++ b/README.Rmd
@@ -140,12 +140,3 @@ dat <- read_labelled_sheet(
 knitr::knit_exit()
 ```
 
-You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this. You could also use GitHub Actions to re-render `README.Rmd` every time you push. An example workflow can be found here: <https://github.com/r-lib/actions/tree/v1/examples>.
-
-You can also embed plots, for example:
-
-```{r pressure, echo = FALSE}
-plot(pressure)
-```
-
-In that case, don't forget to commit and push the resulting figure files, so they display on GitHub and CRAN.

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,10 +84,10 @@ dat2 <- tibble::tibble(
 wb <- createWorkbook()
 
 # default settings name sheet by name of input data
-add_labelled_sheet(dat1)
+add_labelled_sheet(data = dat1, wrkbk = wb)
 
 # you can rename sheet to something more meaningful
-add_labelled_sheet(dat1, "example sheet")
+add_labelled_sheet(data = dat1, sheet_name = "example sheet", wrkbk = wb)
 
 saveWorkbook(wb, "check-wb-1.xlsx")
 ```
@@ -103,7 +103,7 @@ out <- tibble::lst(dat1, dat2)
 wb <- createWorkbook()
 
 # create labelled sheets from all input data
-add_labelled_sheet(out)
+add_labelled_sheet(data = out, wrkbk = wb)
 
 saveWorkbook(wb, "check-wb-2.xlsx")
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,14 @@ add_labelled_sheet(out)
 saveWorkbook(wb, "check-wb-2.xlsx")
 ```
 
-<img src="man/figures/check-wb-2.PNG" title="Shows two tabs named dat1 and dat2. Row 1 has light gray italics text and white background; row 2 has a black background and white text." alt="Shows two tabs named dat1 and dat2. Row 1 has light gray italics text and white background; row 2 has a black background and white text." width="100%" />
+<div class="figure">
+
+<img src="man/figures/check-wb-2.PNG" alt="Shows two tabs named dat1 and dat2. Row 1 has light gray italics text and white background; row 2 has a black background and white text." width="100%" />
+<p class="caption">
+Screenshot of resulting excel output.
+</p>
+
+</div>
 
 ## Importing labelled data from excel
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ dat2 <- tibble::tibble(
 wb <- createWorkbook()
 
 # default settings name sheet by name of input data
-add_labelled_sheet(dat1)
+add_labelled_sheet(data = dat1, wrkbk = wb)
 
 # you can rename sheet to something more meaningful
-add_labelled_sheet(dat1, "example sheet")
+add_labelled_sheet(data = dat1, sheet_name = "example sheet", wrkbk = wb)
 
 saveWorkbook(wb, "check-wb-1.xlsx")
 ```
@@ -97,7 +97,7 @@ out <- tibble::lst(dat1, dat2)
 wb <- createWorkbook()
 
 # create labelled sheets from all input data
-add_labelled_sheet(out)
+add_labelled_sheet(data = out, wrkbk = wb)
 
 saveWorkbook(wb, "check-wb-2.xlsx")
 ```

--- a/man/add_labelled_sheet.Rd
+++ b/man/add_labelled_sheet.Rd
@@ -17,7 +17,7 @@ of input data set}
 \item{start_row}{integer row position where Labels are placed, defaults to 1L}
 }
 \value{
-a workbook object
+a list containing worksheet definition; the function modifies the object passed to the \code{wb} argument.
 }
 \description{
 Row 1 contains variable labels; row 2 contains variable names, freeze panes,

--- a/man/add_labelled_sheet.Rd
+++ b/man/add_labelled_sheet.Rd
@@ -42,8 +42,8 @@ dat1 <- tibble::tibble(
     var_3 = "Variable 3 (date)"
   )
 wb <- createWorkbook()
-add_labelled_sheet(dat1)
-add_labelled_sheet(dat1, sheet_name = "example sheet")
+add_labelled_sheet(data = dat1, wrkbk = wb)
+add_labelled_sheet(data = dat1, sheet_name = "example sheet", wrkbk = wb)
 saveWorkbook(wb, "checkwb.xlsx")
 
 
@@ -61,7 +61,7 @@ dat2 <- tibble::tibble(
 
 out <- tibble::lst(dat1, dat2)
 wb <- createWorkbook()
-add_labelled_sheet(out)
+add_labelled_sheet(data = out, wrkbk = wb)
 saveWorkbook(wb, "checkwb.xlsx")
 }
 

--- a/man/labelled_sheet.Rd
+++ b/man/labelled_sheet.Rd
@@ -17,7 +17,7 @@ of input data set}
 \item{start_row}{integer row position where the labels must be placed, \code{data} is placed at start_row+1, defaults to 1L}
 }
 \value{
-a workbook object
+a list containing worksheet definition; the function modifies the object passed to the \code{wb} argument.
 }
 \description{
 You can add additional styling options to sheet with the openxlsx::add functions


### PR DESCRIPTION
This PR touches only documentation and only in functions related to the labelled data workflow. It follows from [discussion](https://github.com/shannonpileggi/pipinghotdata_distill/discussions/40) under the [related blogpost](https://www.pipinghotdata.com/posts/2022-09-13-the-case-for-variable-labels-in-r/).

It is aimed at making the documentation more precise and also clearer for users unfamiliar with the `openxlsx` workflow where a workbook object is effectively modified in place and need not even be explicitly passed to the `workbook`-type functions.

The PR modifies examples and the README so it is clear what objects are passed to the `add_labelled_sheet()` function parameters.

It also clarifies the documentation of the return value of both `labelled_sheet()` and `add_labelled_sheet()`.

**Question**: should the `labelled_sheet()` and `add_labelled_sheet()` functions return anything at all? I.e. is the return value useable in any subsequent steps that a user might want to take? If not, I would update the PR to make the functions explicitly return NULLs and reflect this in the documentation.