### PR TITLE
Additional `set_derived_variable_labels()` messaging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: croquet
 Title: Miscellaneous Operations for PCCTC
-Version: 0.4.0.9000
+Version: 0.4.0.9001
 Authors@R: c(
     person("Shannon", "Pileggi", , "pileggis@mskcc.org", role = c("aut", "cre")),
     person("Travis", "Gerke", , "gerket@mskcc.org", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # croquet (development version)
 
+* When applying a column label with `set_derived_variable_labels()`, the function will report on any columns whose names end in `.x` or `.y`, as these are likely the result of a merge error.
+
+* When applying a column label with `set_derived_variable_labels()`, the function now reports which columns are being dropped. The report is by the case of the variables, e.g. all lowercase variables are reported together. 
+
 # croquet 0.4.0
 
 ### Breaking Change

--- a/tests/testthat/_snaps/set_derived_variable_labels.md
+++ b/tests/testthat/_snaps/set_derived_variable_labels.md
@@ -1,6 +1,26 @@
 # set_derived_variable_labels() works
 
     Code
+      iris2[1:3, ] %>% dplyr::mutate(UPPERCASE_VAR = TRUE, lowercase_var = TRUE,
+        MiXeDcase_vAr = TRUE, bad_merge_var.x = TRUE, bad_merge_var.y = TRUE) %>%
+        set_derived_variable_labels(df_name = "iris2", path = fs::path_package(
+          "croquet", "derived-variables-example.csv"))
+    Condition
+      Warning:
+      ! The following columns end in ".x" or ".y", which is likely an error: "bad_merge_var.x" and "bad_merge_var.y"
+    Message
+      i The following lowercase columns have been removed: "lowercase_var", "bad_merge_var.x", and "bad_merge_var.y"
+      i The following uppercase columns have been removed: "UPPERCASE_VAR"
+      i The following mixed-case columns have been removed: "Sepal.Width", "Petal.Length", "Petal.Width", and "MiXeDcase_vAr"
+    Output
+        Sepal.Length Species
+      1          5.1  setosa
+      2          4.9  setosa
+      3          4.7  setosa
+
+---
+
+    Code
       iris2 %>% set_derived_variable_labels(path = fs::path_package("croquet",
         "derived-variables-example.csv"))
     Condition
@@ -43,6 +63,7 @@
     Message
       ! Data frame label is not consistent for all rows: "Base R Iris Data Frame" and "Inconsistent DF label".
       i The first label will be used.
+      i The following mixed-case columns have been removed: "Sepal.Width", "Petal.Length", and "Petal.Width"
 
 ---
 

--- a/tests/testthat/test-set_derived_variable_labels.R
+++ b/tests/testthat/test-set_derived_variable_labels.R
@@ -39,6 +39,21 @@ test_that("set_derived_variable_labels() works", {
 
   # expect errors/warnings/notes
   expect_snapshot(
+    iris2[1:3,] %>%
+      dplyr::mutate(
+        UPPERCASE_VAR = TRUE,
+        lowercase_var = TRUE,
+        MiXeDcase_vAr = TRUE,
+        bad_merge_var.x = TRUE,
+        bad_merge_var.y = TRUE
+      ) %>%
+      set_derived_variable_labels(
+        df_name = "iris2",
+        path = fs::path_package("croquet", "derived-variables-example.csv")
+      )
+  )
+
+  expect_snapshot(
     iris2 %>%
       set_derived_variable_labels(
         path = fs::path_package("croquet", "derived-variables-example.csv")

--- a/tests/testthat/test-set_derived_variable_labels.R
+++ b/tests/testthat/test-set_derived_variable_labels.R
@@ -107,4 +107,9 @@ test_that("set_derived_variable_labels() works", {
       ),
     error = TRUE
   )
+
+  expect_error(
+    iris2 |> set_derived_variable_labels(),
+    "must be specified"
+  )
 })


### PR DESCRIPTION
* When applying a column label with `set_derived_variable_labels()`, the function will report on any columns whose names end in `.x` or `.y`, as these are likely the result of a merge error.
* When applying a column label with `set_derived_variable_labels()`, the function now reports which columns are being dropped. The report is by the case of the variables, e.g. all lowercase variables are reported together. 
![image](https://github.com/pcctc/croquet/assets/26774684/7ecc05a8-1edc-4af1-a283-aab3410b47a2)
